### PR TITLE
Adding font awesome and an Icon component

### DIFF
--- a/components/Icon/Icon.jsx
+++ b/components/Icon/Icon.jsx
@@ -1,0 +1,17 @@
+import classNames from "classnames/bind";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+
+import styles from "./Icon.module.scss";
+
+let cx = classNames.bind(styles);
+
+const Icon = ({ name, small, large }) => {
+  let className = cx({
+    "Icon--small": small,
+    "Icon--large": large,
+  });
+
+  return <FontAwesomeIcon className={className} icon={name || "smile"} />;
+};
+
+export default Icon;

--- a/components/Icon/Icon.module.scss
+++ b/components/Icon/Icon.module.scss
@@ -1,0 +1,21 @@
+$icon-small: 1rem;
+$icon-medium: 1.25rem;
+$icon-large: 1.5rem;
+
+.Icon {
+  width: $icon-medium;
+  height: $icon-medium;
+  font-size: $icon-medium;
+
+  &--small {
+    width: $icon-small;
+    height: $icon-small;
+    font-size: $icon-small;
+  }
+
+  &--large {
+    width: $icon-large;
+    height: $icon-large;
+    font-size: $icon-large;
+  }
+}

--- a/components/Icon/index.js
+++ b/components/Icon/index.js
@@ -1,0 +1,3 @@
+import Icon from "./Icon";
+
+export { Icon };

--- a/components/index.js
+++ b/components/index.js
@@ -1,3 +1,7 @@
 export { Button } from "./Button";
+
+export { Icon } from "./Icon";
+
 export { Input } from "./Input";
+
 export { Layout } from "./Layout";

--- a/lib/api.js
+++ b/lib/api.js
@@ -3,7 +3,6 @@ import "firebase/auth";
 
 function initFirebase() {
   if (!firebase.apps.length) {
-    console.log("process.env", process.env);
     firebase.initializeApp({
       apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
       authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1407,6 +1407,35 @@
       "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-0.3.0.tgz",
       "integrity": "sha512-VniCGPIgSGNEgOkh5phb3iKmSGIzcwrccy3IomMFRWPCMiCk2y98UQNJEoDs1yIHtZMstVjYWKYxnunIGzC5UQ=="
     },
+    "@fortawesome/fontawesome-common-types": {
+      "version": "0.2.31",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.31.tgz",
+      "integrity": "sha512-xfnPyH6NN5r/h1/qDYoGB0BlHSID902UkQzxR8QsoKDh55KAPr8ruAoie12WQEEQT8lRE2wtV7LoUllJ1HqCag=="
+    },
+    "@fortawesome/fontawesome-svg-core": {
+      "version": "1.2.31",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.31.tgz",
+      "integrity": "sha512-lqUWRK+ylHQJG5Kiez4XrAZAfc7snxCc+X59quL3xPfMnxzfyf1lt+/hD7X1ZL4KlzAH2KFzMuEVrolo/rAkog==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "^0.2.31"
+      }
+    },
+    "@fortawesome/free-solid-svg-icons": {
+      "version": "5.15.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.15.0.tgz",
+      "integrity": "sha512-4dGRsOnGBPM7c0fd3LuiU6LgRSLn01rw1LJ370yC2iFMLUcLCLLynZhQbMhsiJmMwQM/YmPQblAdyHKVCgsIAA==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "^0.2.31"
+      }
+    },
+    "@fortawesome/react-fontawesome": {
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.11.tgz",
+      "integrity": "sha512-sClfojasRifQKI0OPqTy8Ln8iIhnxR/Pv/hukBhWnBz9kQRmqi6JSH3nghlhAY7SUeIIM7B5/D2G8WjX0iepVg==",
+      "requires": {
+        "prop-types": "^15.7.2"
+      }
+    },
     "@grpc/grpc-js": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.1.7.tgz",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
     "export": "next export"
   },
   "dependencies": {
+    "@fortawesome/fontawesome-svg-core": "^1.2.31",
+    "@fortawesome/free-solid-svg-icons": "^5.15.0",
+    "@fortawesome/react-fontawesome": "^0.1.11",
+    "classnames": "^2.2.6",
     "firebase": "^7.22.0",
     "next": "^9.5.3",
     "react": "^16.13.1",

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,4 +1,9 @@
+import { library } from "@fortawesome/fontawesome-svg-core";
+import { fas } from "@fortawesome/free-solid-svg-icons";
+
 import "../stylesheets/global.scss";
+
+library.add(fas);
 
 export default function MyApp({ Component, pageProps }) {
   return <Component {...pageProps} />;

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,8 +1,16 @@
-import { Layout } from "../components";
+import { Icon, Layout } from "../components";
 
 const HomePage = () => (
   <Layout title="No-Code Overlays App">
-    <h1>Home page works!</h1>
+    <h1>Icons for PR Testing</h1>
+    <p>medium (default)</p>
+    <Icon name="pencil-alt" />
+
+    <p>small</p>
+    <Icon name="pencil-alt" medium />
+
+    <p>large</p>
+    <Icon name="pencil-alt" large />
   </Layout>
 );
 


### PR DESCRIPTION
# Overview

This PR installs the necessary packages for solid FontAwesome icons and adds an`Icon` component to contain all the logic. The Icon currently accepts three props:
- `name`
- `small`
- `large`

The `Icon` component returns a `FontAwesomeIcon` based on the props sent in. It'll use the given `name` prop or return a `smile` icon by default. The `small` and `large` props help determine what size icon to return. The sizes are specified in `Icon.module.scss` and the default size is `medium` and 20px.

# Relevant Issues

- #4 Set up FontAwesome

# Testing

- [x] Go to the home page
- [x] It should look like this:

![Screen Shot 2020-10-04 at 6 22 06 PM](https://user-images.githubusercontent.com/43934258/95028492-8441b500-066e-11eb-8731-c2e794fb6d9d.png)

- [x] The first icon should be 16px square
- [x] The second icon should be 20px square
- [x] The third icon should be 24px square