### PR TITLE
Feature/add edit overlay page

### DIFF
--- a/components/Layout/Layout.jsx
+++ b/components/Layout/Layout.jsx
@@ -30,7 +30,7 @@ const Layout = ({ title, children }) => {
   return (
     <div className={styles.Layout}>
       <Head>
-        <title>{title}</title>
+        <title>{"No Code Overlays" || title}</title>
         <meta name="viewport" content="initial-scale=1.0, width=device-width" />
       </Head>
       <header>

--- a/lib/api.js
+++ b/lib/api.js
@@ -21,7 +21,12 @@ export async function getUser() {
 export async function signIn(email, password) {
   initFirebase();
 
-  return firebase.auth().signInWithEmailAndPassword(email, password);
+  return firebase
+    .auth()
+    .setPersistence(firebase.auth.Auth.Persistence.SESSION)
+    .then(() => {
+      return firebase.auth().signInWithEmailAndPassword(email, password);
+    });
 }
 
 export async function signOut() {

--- a/pages/edit/overlay.js
+++ b/pages/edit/overlay.js
@@ -1,0 +1,9 @@
+import { Layout } from "../../components";
+
+const EditOverlayPage = () => (
+  <Layout title="Edit Overlay">
+    <h1>Hello, EditOverlayPage!</h1>
+  </Layout>
+);
+
+export default EditOverlayPage;

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,16 +1,12 @@
-import { Icon, Layout } from "../components";
+import Link from "next/link";
+import { Layout } from "../components";
 
 const HomePage = () => (
   <Layout title="No-Code Overlays App">
     <h1>Icons for PR Testing</h1>
-    <p>medium (default)</p>
-    <Icon name="pencil-alt" />
-
-    <p>small</p>
-    <Icon name="pencil-alt" medium />
-
-    <p>large</p>
-    <Icon name="pencil-alt" large />
+    <Link href="/edit/overlay">
+      <a>Edit Overlay</a>
+    </Link>
   </Layout>
 );
 

--- a/pages/login.js
+++ b/pages/login.js
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import Head from "next/head";
 import { useRouter } from "next/router";
 import { signIn } from "../lib/api";
 
@@ -12,6 +13,10 @@ const LoginPage = () => {
 
   return (
     <div className={styles.Login}>
+      <Head>
+        <title>No Code Overlays | Log In</title>
+        <meta name="viewport" content="initial-scale=1.0, width=device-width" />
+      </Head>
       <div>
         <h1>Welcome to No-Code Overlays!</h1>
         <h2>Please log in to get going.</h2>


### PR DESCRIPTION
# Overview

This PR adds a new `pages/edit/overlay.js` file for the "Edit Overlay" page at `/edit/overlay`. I also included a few other small things:

- Setting the Firebase persistence to `SESSION` on sign in
- Having a default title for pages that use the `Layout` component
- Setting the page title on the `Login` page

# Relevant Issues

- closes #8 Add page for overlay editor under `/edit/overlay`

# Testing

- [x] Go to the home page
- [x] It should look like this:

![Screen Shot 2020-10-04 at 6 51 26 PM](https://user-images.githubusercontent.com/43934258/95028976-9e7d9200-0672-11eb-8a66-6f639aaff5fb.png)

- [x] Visit the "Edit Overlay" link
- [x] You should be taken to `/edit/overlay`
- [x] It should look like this:

![Screen Shot 2020-10-04 at 6 52 24 PM](https://user-images.githubusercontent.com/43934258/95028987-bf45e780-0672-11eb-9bdf-cdf147395886.png)