### PR TITLE
Feature/edit overlay sidebar

### DIFF
--- a/components/Layout/Layout.module.scss
+++ b/components/Layout/Layout.module.scss
@@ -1,5 +1,8 @@
+@import "../../stylesheets/variables";
+
 .Layout {
   header {
+    height: $header-height;
     display: flex;
     justify-content: space-between;
     align-items: center;
@@ -15,5 +18,6 @@
 
   main {
     padding: 24px;
+    position: relative;
   }
 }

--- a/components/Sidebar/Sidebar.jsx
+++ b/components/Sidebar/Sidebar.jsx
@@ -1,0 +1,7 @@
+import styles from "./Sidebar.module.scss";
+
+const Sidebar = () => {
+  return <div className={styles.Sidebar}>The Sidebar</div>;
+};
+
+export default Sidebar;

--- a/components/Sidebar/Sidebar.module.scss
+++ b/components/Sidebar/Sidebar.module.scss
@@ -1,0 +1,12 @@
+@import "../../stylesheets/variables";
+
+.Sidebar {
+  width: 300px;
+  height: calc(100vh - #{$header-height});
+  background-color: #f5f5f5;
+  box-shadow: 0 0 6px rgba(0, 0, 0, 0.5);
+  position: absolute;
+  top: 0;
+  right: 0;
+  padding: 12px;
+}

--- a/components/Sidebar/index.js
+++ b/components/Sidebar/index.js
@@ -1,0 +1,3 @@
+import Sidebar from "./Sidebar";
+
+export { Sidebar };

--- a/components/index.js
+++ b/components/index.js
@@ -5,3 +5,5 @@ export { Icon } from "./Icon";
 export { Input } from "./Input";
 
 export { Layout } from "./Layout";
+
+export { Sidebar } from "./Sidebar";

--- a/pages/edit/overlay.js
+++ b/pages/edit/overlay.js
@@ -1,8 +1,13 @@
-import { Layout } from "../../components";
+import { Layout, Sidebar } from "../../components";
+
+import styles from "../../stylesheets/Pages.module.scss";
 
 const EditOverlayPage = () => (
   <Layout title="Edit Overlay">
-    <h1>Hello, EditOverlayPage!</h1>
+    <div className={styles.EditOverlay}>
+      <div>This is where the overlay contents will go</div>
+      <Sidebar />
+    </div>
   </Layout>
 );
 

--- a/stylesheets/Pages.module.scss
+++ b/stylesheets/Pages.module.scss
@@ -1,6 +1,3 @@
-.Home {
-}
-
 .Login {
   height: 100vh;
   display: flex;

--- a/stylesheets/_variables.scss
+++ b/stylesheets/_variables.scss
@@ -1,0 +1,1 @@
+$header-height: 74px;


### PR DESCRIPTION
# Overview

This PR adds a `Sidebar` component for the overlay editor page. It will eventually have all of the configurable options for an overlay. For now, it shows on top of the area where the custom overlay will be displayed.

# Relevant Issues

- closes #7 Add a Sidebar component for the overlay editor

# Testing

- [x] Go to the overlay editor page (link on home page)
- [x] It should look like this:

![Screen Shot 2020-10-04 at 8 18 10 PM](https://user-images.githubusercontent.com/43934258/95030575-bbb85d80-067e-11eb-8815-acd3efc0321b.png)
