### PR TITLE
Feature/allow dimension saving

### DIFF
--- a/components/Sidebar/Sidebar.jsx
+++ b/components/Sidebar/Sidebar.jsx
@@ -1,7 +1,7 @@
 import styles from "./Sidebar.module.scss";
 
-const Sidebar = () => {
-  return <div className={styles.Sidebar}>The Sidebar</div>;
+const Sidebar = ({ children }) => {
+  return <div className={styles.Sidebar}>{children}</div>;
 };
 
 export default Sidebar;

--- a/components/Sidebar/Sidebar.module.scss
+++ b/components/Sidebar/Sidebar.module.scss
@@ -9,4 +9,11 @@
   top: 0;
   right: 0;
   padding: 12px;
+
+  // Section of the Sidebar
+  & > div {
+    h2 {
+      margin-bottom: 12px;
+    }
+  }
 }

--- a/lib/api.js
+++ b/lib/api.js
@@ -1,5 +1,6 @@
 import firebase from "firebase/app";
 import "firebase/auth";
+import "firebase/database";
 
 function initFirebase() {
   if (!firebase.apps.length) {
@@ -33,4 +34,28 @@ export async function signOut() {
   initFirebase();
 
   return firebase.auth().signOut();
+}
+
+export async function getOverlayData() {
+  const currentUser = firebase.auth().currentUser;
+  if (!currentUser) {
+    return;
+  }
+
+  return firebase
+    .database()
+    .ref(`/overlays/${currentUser.uid}`)
+    .once("value")
+    .then((snapshot) => {
+      return snapshot.val();
+    });
+}
+
+export async function updateOverlayData(data) {
+  const currentUser = firebase.auth().currentUser;
+  if (!currentUser) {
+    return;
+  }
+
+  return firebase.database().ref(`/overlays/${currentUser.uid}`).update(data);
 }

--- a/lib/api.js
+++ b/lib/api.js
@@ -37,6 +37,8 @@ export async function signOut() {
 }
 
 export async function getOverlayData() {
+  initFirebase();
+
   const currentUser = firebase.auth().currentUser;
   if (!currentUser) {
     return;
@@ -52,6 +54,8 @@ export async function getOverlayData() {
 }
 
 export async function updateOverlayData(data) {
+  initFirebase();
+
   const currentUser = firebase.auth().currentUser;
   if (!currentUser) {
     return;

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,3 @@
 [build]
-  command = "rm -rf /.github && npm run build && npm run export"
+  command = "npm run build && npm run export"
   publish = "out"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,3 @@
 [build]
-  command = "npm run build && npm run export"
+  command = "rm -rf ./.github && npm run build && npm run export"
   publish = "out"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,3 @@
 [build]
-  command = "rm -rf ./.github && npm run build && npm run export"
+  command = "rm -rf /.github && npm run build && npm run export"
   publish = "out"

--- a/pages/edit/overlay.js
+++ b/pages/edit/overlay.js
@@ -1,14 +1,67 @@
-import { Layout, Sidebar } from "../../components";
-
+import { useState } from "react";
+import { getOverlayData, updateOverlayData } from "../../lib/api";
+import { Button, Input, Layout, Sidebar } from "../../components";
 import styles from "../../stylesheets/Pages.module.scss";
 
-const EditOverlayPage = () => (
-  <Layout title="Edit Overlay">
-    <div className={styles.EditOverlay}>
-      <div>This is where the overlay contents will go</div>
-      <Sidebar />
-    </div>
-  </Layout>
-);
+const EditOverlayPage = ({ data }) => {
+  const [isSaving, setIsSaving] = useState(false);
+  const [width, setWidth] = useState(data ? data.width : "");
+  const [height, setHeight] = useState(data ? data.height : "");
+
+  return (
+    <Layout title="Edit Overlay">
+      <div className={styles.EditOverlay}>
+        <p>Your Preview</p>
+        <div
+          style={{
+            width: `${width}px`,
+            height: `${height}px`,
+            border: "1px solid black",
+          }}
+        ></div>
+        <Sidebar>
+          <div>
+            <div>
+              <h2>Dimensions</h2>
+            </div>
+            <Input
+              id="width"
+              type="number"
+              label="Width (px)"
+              value={width}
+              onChange={setWidth}
+            />
+            <Input
+              id="height"
+              type="number"
+              label="Height (px)"
+              value={height}
+              onChange={setHeight}
+            />
+          </div>
+          <Button
+            disabled={isSaving}
+            onClick={() => {
+              setIsSaving(true);
+              updateOverlayData({ width, height }).then(() => {
+                setIsSaving(false);
+              });
+            }}
+          >
+            {isSaving ? "Saving..." : "Save"}
+          </Button>
+        </Sidebar>
+      </div>
+    </Layout>
+  );
+};
+
+EditOverlayPage.getInitialProps = async () => {
+  const overlayData = await getOverlayData();
+
+  return {
+    data: overlayData,
+  };
+};
 
 export default EditOverlayPage;

--- a/stylesheets/Pages.module.scss
+++ b/stylesheets/Pages.module.scss
@@ -27,3 +27,9 @@
     }
   }
 }
+
+.EditOverlay {
+  p {
+    margin-bottom: 24px;
+  }
+}


### PR DESCRIPTION
# Overview

This PR adds the ability to update the width and height of an overlay using the Overlay Editor. I had to first set up the Firebase Database, then added some Firebase API functions to `/lib/api.js`, and finally added inputs and a "Save" button to the sidebar of the editor.

# Relevant issues

- closes #9 (Allow overlay dimensions to be edited and saved in the DB)

# Testing

- [x] Log in with the test credentials
   - **email:** test@test.com
   - **password:** testing
- [x] Go to the Overlay Editor with the "Edit Overlay" link
- [x] The page should look like this:

![Screen Shot 2020-10-08 at 2 28 12 PM](https://user-images.githubusercontent.com/43934258/95498919-8196d680-0972-11eb-992f-8fd412a64e13.png)

- [x] Modify the width and/or height and remember the new values
- [x] Click the "Save" button
- [x] Refresh the page (Log back in if needed)
- [x] The new values should still show in the inputs