### PR TITLE
Adding new modal component and showing in home page for testing

### DIFF
--- a/components/Layout/Layout.module.scss
+++ b/components/Layout/Layout.module.scss
@@ -1,4 +1,4 @@
-@import "../../stylesheets/variables";
+@import '../../stylesheets/variables';
 
 .Layout {
   header {
@@ -18,6 +18,5 @@
 
   main {
     padding: 24px;
-    position: relative;
   }
 }

--- a/components/Modal/Modal.jsx
+++ b/components/Modal/Modal.jsx
@@ -1,0 +1,21 @@
+import { Button, Icon } from '../';
+import styles from './Modal.module.scss';
+
+const Modal = ({ children, title, onClose, buttons = [] }) => (
+  <div className={styles.Modal}>
+    <div className={styles['Modal--container']}>
+      <div className={styles['Modal--header']}>
+        <h1>{title}</h1>
+        <Button onClick={onClose}>
+          <Icon name="times" />
+        </Button>
+      </div>
+      <div className={styles['Modal--body']}>{children}</div>
+      <div className={styles['Modal--footer']}>
+        {buttons.map((button) => button)}
+      </div>
+    </div>
+  </div>
+);
+
+export default Modal;

--- a/components/Modal/Modal.module.scss
+++ b/components/Modal/Modal.module.scss
@@ -1,0 +1,44 @@
+.Modal {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  background-color: rgba(#000, 0.4);
+  padding: 48px 24px;
+
+  &--container {
+    width: 100%;
+    max-width: 700px;
+    padding: 24px;
+    margin: 0 auto;
+    background-color: white;
+    border-radius: 16px;
+  }
+
+  &--header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+
+    button {
+      background-color: transparent;
+      border: none;
+      box-shadow: none;
+      color: black;
+    }
+  }
+
+  &--body {
+    padding-top: 24px;
+  }
+
+  &--footer {
+    text-align: right;
+    padding-top: 24px;
+
+    & > *:not(:last-child) {
+      margin-right: 12px;
+    }
+  }
+}

--- a/components/Modal/index.js
+++ b/components/Modal/index.js
@@ -1,0 +1,3 @@
+import Modal from "./Modal";
+
+export { Modal };

--- a/components/index.js
+++ b/components/index.js
@@ -1,9 +1,11 @@
-export { Button } from "./Button";
+export { Button } from './Button';
 
-export { Icon } from "./Icon";
+export { Icon } from './Icon';
 
-export { Input } from "./Input";
+export { Input } from './Input';
 
-export { Layout } from "./Layout";
+export { Layout } from './Layout';
 
-export { Sidebar } from "./Sidebar";
+export { Modal } from './Modal';
+
+export { Sidebar } from './Sidebar';

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,13 +1,38 @@
-import Link from "next/link";
-import { Layout } from "../components";
+import { useState } from 'react';
+import { Button, Layout, Modal } from '../components';
 
-const HomePage = () => (
-  <Layout title="No-Code Overlays App">
-    <h1>Icons for PR Testing</h1>
-    <Link href="/edit/overlay">
-      <a>Edit Overlay</a>
-    </Link>
-  </Layout>
-);
+const HomePage = () => {
+  const [showModal, setShowModal] = useState(false);
+
+  return (
+    <Layout title="No-Code Overlays App">
+      <h1>Temporary area for testing things</h1>
+      <br />
+
+      <Button
+        onClick={() => {
+          setShowModal(!showModal);
+        }}
+      >
+        Open Modal
+      </Button>
+      {showModal && (
+        <Modal
+          title="Modal title"
+          onClose={() => {
+            setShowModal(false);
+          }}
+          buttons={[
+            <Button>Hi</Button>,
+            <Button>Hi</Button>,
+            <Button>Hi</Button>,
+          ]}
+        >
+          <h2>Hi, I'm a modal!</h2>
+        </Modal>
+      )}
+    </Layout>
+  );
+};
 
 export default HomePage;


### PR DESCRIPTION
# Overview

This PR adds a basic `Modal` component with four props:

- `children`: things to be rendered in the modal body
- `title`: text to put at the top of the modal
- `onClose`: function to invoke when the close button is activated
- `buttons`: buttons to render at the bottom of the modal

# Relevant issues

- closes #19 Add `Modal` component

# Testing

- [x] Visit the deploy preview after the Netlify checks pass
- [x] Log in using the testing credentials (**email:** test@test.com, **password:** testing)
- [x] The page should look like this:

![CleanShot 2020-10-21 at 18 20 00](https://user-images.githubusercontent.com/43934258/96793275-12859d00-13ca-11eb-8f08-335e3104204a.png)

- [x] Activate the "Open Modal" button
- [x] The modal should open and look like this:

![CleanShot 2020-10-21 at 18 20 47](https://user-images.githubusercontent.com/43934258/96793336-2b8e4e00-13ca-11eb-9463-1806f0e03c6f.png)

- [x] Activate the close button at the top right of the modal
- [x] The modal should close