### PR TITLE
Adding image widget

### DIFF
--- a/pages/edit/overlay.js
+++ b/pages/edit/overlay.js
@@ -15,6 +15,13 @@ const typesToAttributes = {
     { id: 'yPosition', label: 'Y Position', type: 'number' },
     { id: 'color', label: 'Color (Hex)', type: 'text' },
   ],
+  image: [
+    { id: 'width', label: 'Width', type: 'number' },
+    { id: 'height', label: 'Height', type: 'number' },
+    { id: 'xPosition', label: 'X Position', type: 'number' },
+    { id: 'yPosition', label: 'Y Position', type: 'number' },
+    { id: 'url', label: 'URL', type: 'text' },
+  ],
 };
 
 const AddWidgetModal = ({ onClose, onAdd }) => {
@@ -46,6 +53,7 @@ const AddWidgetModal = ({ onClose, onAdd }) => {
       >
         <option value="">Choose a type</option>
         <option value="color">Color Block</option>
+        <option value="image">Image</option>
       </select>
 
       {widgetType && (
@@ -93,11 +101,12 @@ const EditOverlayPage = ({ data }) => {
             border: '1px solid black',
           }}
         >
-          {Object.keys(widgets).map((widgetKey) => {
+          {Object.keys(widgets).map((widgetKey, index) => {
             const widget = widgets[widgetKey];
             if (widget.type === 'color') {
               return (
                 <div
+                  key={`widget-${index}`}
                   style={{
                     width: `${widget.width}px`,
                     height: `${widget.height}px`,
@@ -107,6 +116,20 @@ const EditOverlayPage = ({ data }) => {
                     left: `${widget.xPosition}px`,
                   }}
                 ></div>
+              );
+            } else if (widget.type === 'image') {
+              return (
+                <img
+                  key={`widget-${index}`}
+                  src={widget.url}
+                  style={{
+                    width: `${widget.width}px`,
+                    height: `${widget.height}px`,
+                    position: 'absolute',
+                    top: `${widget.yPosition}px`,
+                    left: `${widget.xPosition}px`,
+                  }}
+                />
               );
             }
           })}


### PR DESCRIPTION
# Overview

This PR adds the ability to add image widgets in the overlay editor.

# Relevant issues

- closes #17 New widget: image

# Testing

- [x] Visit the deploy preview after the Netlify checks pass
- [x] Log in using the testing credentials (email: test@test.com, password: testing)
- [x] Follow the "Edit Overlay" link
- [x] The sidebar should read "No widgets yet."
- [x] Add a "Color Block" widget with these attributes:
  - width: 300
  - height: 300
  - xPosition: 150
  - yPosition: 150
  - color: black
- [x] Open the "Add a widget" modal again
- [x] Choose "Image" from the "Widget type" dropdown
- [x] The modal should look like this:

![CleanShot 2020-10-22 at 08 45 52](https://user-images.githubusercontent.com/43934258/96873493-01c53d80-1443-11eb-9858-7490155bbf1f.png)

- [x] Add an "Image" widget with these attributes:
  - width: 300
  - height: 300
  - xPosition: 154
  - yPosition: 146
  - url: https://placekitten.com/g/300/300
- [x] The overlay preview should look something like this (the image may be different):

![CleanShot 2020-10-22 at 08 49 36](https://user-images.githubusercontent.com/43934258/96873902-8617c080-1443-11eb-91f9-113410e07124.png)