### PR TITLE
Feature/new text block widget

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -1,6 +1,6 @@
-import firebase from "firebase/app";
-import "firebase/auth";
-import "firebase/database";
+import firebase from 'firebase/app';
+import 'firebase/auth';
+import 'firebase/database';
 
 function initFirebase() {
   if (!firebase.apps.length) {
@@ -47,11 +47,8 @@ export async function getOverlayData() {
   return firebase
     .database()
     .ref(`/overlays/${currentUser.uid}`)
-    .once("value")
-    .then((snapshot) => {
-      console.log("VALUE", snapshot.val());
-      return snapshot.val();
-    });
+    .once('value')
+    .then((snapshot) => snapshot.val());
 }
 
 export async function updateOverlayData(data) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2826,6 +2826,14 @@
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
     },
+    "@samuelmeuli/font-manager": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@samuelmeuli/font-manager/-/font-manager-1.4.0.tgz",
+      "integrity": "sha512-TaPoX4qA6ABrACiSI18lQOOKjvbLNrT+84UWfzwcguWQ4nT+sprOSRyt/RVXnt9fQp/wFQVC2NcHbzd+AkXffg==",
+      "requires": {
+        "@babel/runtime": "^7.7.4"
+      }
+    },
     "@sinonjs/commons": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.1.tgz",
@@ -6008,6 +6016,14 @@
       "requires": {
         "inherits": "^2.0.3",
         "readable-stream": "^2.3.6"
+      }
+    },
+    "font-picker-react": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/font-picker-react/-/font-picker-react-3.5.2.tgz",
+      "integrity": "sha512-0JkWIDf2hi6JwnvjIiacLDhO+Sl38RQ4mUGhCWN+Hvj95XalVZ0Aq5zJs/Ybend4uk2yI9rd1QhRRF9RnfHqIQ==",
+      "requires": {
+        "@samuelmeuli/font-manager": "^1.4.0"
       }
     },
     "for-in": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2826,14 +2826,6 @@
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
     },
-    "@samuelmeuli/font-manager": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@samuelmeuli/font-manager/-/font-manager-1.4.0.tgz",
-      "integrity": "sha512-TaPoX4qA6ABrACiSI18lQOOKjvbLNrT+84UWfzwcguWQ4nT+sprOSRyt/RVXnt9fQp/wFQVC2NcHbzd+AkXffg==",
-      "requires": {
-        "@babel/runtime": "^7.7.4"
-      }
-    },
     "@sinonjs/commons": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.1.tgz",
@@ -6016,14 +6008,6 @@
       "requires": {
         "inherits": "^2.0.3",
         "readable-stream": "^2.3.6"
-      }
-    },
-    "font-picker-react": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/font-picker-react/-/font-picker-react-3.5.2.tgz",
-      "integrity": "sha512-0JkWIDf2hi6JwnvjIiacLDhO+Sl38RQ4mUGhCWN+Hvj95XalVZ0Aq5zJs/Ybend4uk2yI9rd1QhRRF9RnfHqIQ==",
-      "requires": {
-        "@samuelmeuli/font-manager": "^1.4.0"
       }
     },
     "for-in": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13356,6 +13356,11 @@
       "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-0.2.4.tgz",
       "integrity": "sha512-6BjspCO9VriYy12z356nL6JBS0GYeEcA457YyRzD+dD6XYCQ75NKhcOHUMHentOE7OcVCIXXDvOm0jKFfQG2Gg=="
     },
+    "webfontloader": {
+      "version": "1.6.28",
+      "resolved": "https://registry.npmjs.org/webfontloader/-/webfontloader-1.6.28.tgz",
+      "integrity": "sha1-23hhKSU8tujq5UwvsF+HCvZnW64="
+    },
     "webidl-conversions": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@fortawesome/react-fontawesome": "^0.1.11",
     "classnames": "^2.2.6",
     "firebase": "^7.24.0",
+    "font-picker-react": "^3.5.2",
     "next": "^9.5.5",
     "react": "^17.0.0",
     "react-dom": "^17.0.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "@fortawesome/react-fontawesome": "^0.1.11",
     "classnames": "^2.2.6",
     "firebase": "^7.24.0",
-    "font-picker-react": "^3.5.2",
     "next": "^9.5.5",
     "react": "^17.0.0",
     "react-dom": "^17.0.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "next": "^9.5.5",
     "react": "^17.0.0",
     "react-dom": "^17.0.0",
-    "sass": "^1.27.0"
+    "sass": "^1.27.0",
+    "webfontloader": "^1.6.28"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.11.4",

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,7 +1,7 @@
-import { library } from "@fortawesome/fontawesome-svg-core";
-import { fas } from "@fortawesome/free-solid-svg-icons";
-
-import "../stylesheets/global.scss";
+import { library } from '@fortawesome/fontawesome-svg-core';
+import { fas } from '@fortawesome/free-solid-svg-icons';
+import '@amb-codes-crafts/a11y-components/dist/index.css';
+import '../stylesheets/global.scss';
 
 library.add(fas);
 

--- a/pages/edit/overlay.js
+++ b/pages/edit/overlay.js
@@ -1,5 +1,4 @@
-import { useEffect, useState } from 'react';
-import FontPicker from 'font-picker-react';
+import { useLayoutEffect, useState } from 'react';
 import {
   createOverlayWidget,
   getOverlayData,
@@ -31,11 +30,6 @@ const typesToAttributes = {
     { id: 'yPosition', label: 'Y Position', type: 'number' },
   ],
 };
-
-const webFontLoaderScriptTag = document.createElement('script');
-webFontLoaderScriptTag.src =
-  'https://ajax.googleapis.com/ajax/libs/webfont/1.6.26/webfont.js';
-document.head.appendChild(webFontLoaderScriptTag);
 
 const AddWidgetModal = ({ onClose, onAdd }) => {
   const [widgetType, setWidgetType] = useState('');
@@ -76,6 +70,7 @@ const AddWidgetModal = ({ onClose, onAdd }) => {
             if (id === 'fontFamily') {
               return (
                 <FontPicker
+                  key={`widgetInput-${id}`}
                   apiKey={
                     process.env.NEXT_PUBLIC_GOOGLE_WEB_FONTS_DEVELOPER_API_KEY
                   }
@@ -113,6 +108,8 @@ const AddWidgetModal = ({ onClose, onAdd }) => {
   );
 };
 
+let FontPicker;
+
 const EditOverlayPage = ({ data }) => {
   const [showAddWidgetModal, setShowAddWidgetModal] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
@@ -122,14 +119,20 @@ const EditOverlayPage = ({ data }) => {
     data && data.widgets ? data.widgets : {}
   );
 
-  useEffect(() => {
-    WebFont.load({
-      google: {
-        families: Object.keys(widgets)
-          .filter((widgetKey) => widgets[widgetKey].type === 'text')
-          .map((widgetKey) => widgets[widgetKey].fontFamily.family),
-      },
-    });
+  useLayoutEffect(() => {
+    FontPicker = require('font-picker-react');
+    const WebFont = require('webfontloader');
+    const familiesToLoad = Object.keys(widgets)
+      .filter((widgetKey) => widgets[widgetKey].type === 'text')
+      .map((widgetKey) => widgets[widgetKey].fontFamily.family);
+
+    if (familiesToLoad.length) {
+      WebFont.load({
+        google: {
+          families: familiesToLoad,
+        },
+      });
+    }
   }, []);
 
   return (
@@ -236,6 +239,7 @@ const EditOverlayPage = ({ data }) => {
                     const widget = widgets[widgetKey];
                     return (
                       <div
+                        key={`widget-${widgetKey}`}
                         style={{
                           border: '1px solid gray',
                           borderRadius: '4px',
@@ -246,7 +250,10 @@ const EditOverlayPage = ({ data }) => {
                         }}
                       >
                         {Object.keys(widget).map((attribute) => (
-                          <span style={{ display: 'block' }}>
+                          <span
+                            key={`widgetAttribute-${attribute}-${widgetKey}`}
+                            style={{ display: 'block' }}
+                          >
                             <strong>{attribute}:</strong>{' '}
                             {widget[attribute].family
                               ? widget[attribute].family

--- a/pages/edit/overlay.js
+++ b/pages/edit/overlay.js
@@ -80,7 +80,6 @@ const AddWidgetModal = ({ onClose, onAdd }) => {
                     process.env.NEXT_PUBLIC_GOOGLE_WEB_FONTS_DEVELOPER_API_KEY
                   }
                   onChange={(value) => {
-                    console.log(value);
                     setAttributes({
                       ...attributes,
                       [id]: value,
@@ -130,16 +129,6 @@ const EditOverlayPage = ({ data }) => {
           .filter((widgetKey) => widgets[widgetKey].type === 'text')
           .map((widgetKey) => widgets[widgetKey].fontFamily.family),
       },
-      loading: () => {
-        console.log('Fonts are being loaded...');
-      },
-      active: () => {
-        console.log('Fonts have been rendered');
-      },
-      fontloading: (familyName, fvd) => {
-        console.log(familyName);
-        console.log(fvd);
-      },
     });
   }, []);
 
@@ -186,7 +175,6 @@ const EditOverlayPage = ({ data }) => {
                 />
               );
             } else if (widget.type === 'text') {
-              console.log(widget.fontFamily.family);
               return (
                 <span
                   key={`widget-${index}`}


### PR DESCRIPTION
# Overview

This PR adds the ability to add text block widgets in the overlay editor.

# Relevant issues

- closes #18 New widget: text block

# Testing

- [x] Go to the overlay editor
- [x] It should look like this:

![CleanShot 2020-10-22 at 16 20 50](https://user-images.githubusercontent.com/43934258/96925719-969b5b80-1482-11eb-8ba4-d8f7f578d035.png)

- [x] Remove the last widget in the list
- [x] Open the "Add a widget" modal
- [x] Select "Text Block" from the "Widget type" dropdown
- [x] The modal should look like this:

![CleanShot 2020-10-22 at 16 21 44](https://user-images.githubusercontent.com/43934258/96925801-b2066680-1482-11eb-93c1-d26ec321a79b.png)

- [x] Enter the following attributes and add the widget:
  - text: Let's try another
  - font family: Staatliches
  - font size: 12
  - x position: 100
  - y position: 450
- [x] The editor should look like this:

![CleanShot 2020-10-22 at 16 24 13](https://user-images.githubusercontent.com/43934258/96926024-07db0e80-1483-11eb-92d0-9e7ab9d5bb2f.png)