### PR TITLE
Making page header a link

### DIFF
--- a/components/Layout/Layout.jsx
+++ b/components/Layout/Layout.jsx
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import Head from 'next/head';
+import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { Button } from '@amb-codes-crafts/a11y-components';
 import classNames from 'classnames/bind';
@@ -42,7 +43,11 @@ const Layout = ({ title, children, fullscreen }) => {
         <meta name="viewport" content="initial-scale=1.0, width=device-width" />
       </Head>
       <header>
-        <h1>No-Code Overlays</h1>
+        <Link href="/">
+          <h1>
+            <a>No-Code Overlays</a>
+          </h1>
+        </Link>
         <div>
           <span>Hey, {user.email}!</span>
           <Button

--- a/components/Layout/Layout.module.scss
+++ b/components/Layout/Layout.module.scss
@@ -13,6 +13,16 @@
     color: white;
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
 
+    a {
+      color: inherit;
+      text-decoration: none;
+
+      &:hover {
+        text-decoration: underline;
+        cursor: pointer;
+      }
+    }
+
     span {
       margin-right: 8px;
     }


### PR DESCRIPTION
# Overview

This PR adds navigation to the home page from other pages by updating the "No-Code Overlays" `h1` element in the `Layout` component. Fixes #29.

# Testing

Make sure you can get to the home page from pages that render the `Layout` component with a header.