### PR TITLE
Updating greeting to show displayName if it is set

### DIFF
--- a/components/Layout/Layout.jsx
+++ b/components/Layout/Layout.jsx
@@ -49,7 +49,7 @@ const Layout = ({ title, children, fullscreen }) => {
           </h1>
         </Link>
         <div>
-          <span>Hey, {user.email}!</span>
+          <span>Hey, {user.displayName || user.email}!</span>
           <Button
             onClick={() => {
               firebaseAPI('signOut');

--- a/components/Layout/Layout.test.jsx
+++ b/components/Layout/Layout.test.jsx
@@ -1,0 +1,33 @@
+import { shallow } from 'enzyme';
+import { useAuth } from '../../context/auth';
+import Layout from './Layout';
+
+jest.mock('../../context/auth');
+
+describe('<Layout />', () => {
+  describe('greeting', () => {
+    it('greets the user by `displayName` if there is one set', () => {
+      useAuth.mockReturnValueOnce({
+        user: {
+          displayName: 'TestUser',
+        },
+        userLoading: false,
+      });
+
+      const wrapper = shallow(<Layout />);
+      expect(wrapper.find('span').text()).toBe('Hey, TestUser!');
+    });
+
+    it('greets the user by email if no `displayName` set', () => {
+      useAuth.mockReturnValueOnce({
+        user: {
+          email: 'test@test.com',
+        },
+        userLoading: false,
+      });
+
+      const wrapper = shallow(<Layout />);
+      expect(wrapper.find('span').text()).toBe('Hey, test@test.com!');
+    });
+  });
+});

--- a/components/Layout/Layout.test.jsx
+++ b/components/Layout/Layout.test.jsx
@@ -4,30 +4,34 @@ import Layout from './Layout';
 
 jest.mock('../../context/auth');
 
+const mockUser = {
+  displayName: 'TestUser',
+  email: 'test@test.com',
+};
+
 describe('<Layout />', () => {
   describe('greeting', () => {
-    it('greets the user by `displayName` if there is one set', () => {
+    it('greets the user by email if no `displayName` set', () => {
+      const mockUserCopy = { ...mockUser };
+      delete mockUserCopy.displayName;
+
       useAuth.mockReturnValueOnce({
-        user: {
-          displayName: 'TestUser',
-        },
+        user: mockUserCopy,
         userLoading: false,
       });
 
       const wrapper = shallow(<Layout />);
-      expect(wrapper.find('span').text()).toBe('Hey, TestUser!');
+      expect(wrapper.find('span').text()).toBe(`Hey, ${mockUser.email}!`);
     });
 
-    it('greets the user by email if no `displayName` set', () => {
+    it('greets the user by `displayName` if there is one set', () => {
       useAuth.mockReturnValueOnce({
-        user: {
-          email: 'test@test.com',
-        },
+        user: mockUser,
         userLoading: false,
       });
 
       const wrapper = shallow(<Layout />);
-      expect(wrapper.find('span').text()).toBe('Hey, test@test.com!');
+      expect(wrapper.find('span').text()).toBe(`Hey, ${mockUser.displayName}!`);
     });
   });
 });


### PR DESCRIPTION
# Overview

This PR shows the user's display name in the header greeting if they have set one. It shows the user's email by default. I've also added tests for the greeting. Fixes #30.

# Testing

- [ ] Set a display name in the profile settings
- [ ] Make sure the greeting says "Hey, {displayName}!"
- [ ] Delete the display name
- [ ] Make sure the greeting says "Hey, {emailAddress}!"